### PR TITLE
fix: README - align with TestMu AI branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-# Run TestCafe SDK Tests on TestMu AI (Formerly LambdaTest)
+# TestCafe SDK for TestMu AI (Formerly LambdaTest)
 
 <p align="center">
   <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
+  <a href="https://npmjs.org/package/@lambdatest/lambdatest-testcafe-sdk"><img src="https://img.shields.io/npm/v/@lambdatest/lambdatest-testcafe-sdk.svg?style=for-the-badge&labelColor=000" alt="npm version"></a>
   <a href="https://community.testmuai.com/"><img src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&labelColor=000000" alt="Community"></a>
 </p>
 
@@ -9,7 +10,7 @@
 
 [TestMu AI](https://www.testmuai.com/) (Formerly LambdaTest) is the world's first full-stack AI Agentic Quality Engineering platform that empowers teams to test intelligently, smarter, and ship faster. Built for scale, it offers a full-stack testing cloud with 10K+ real devices and 3,000+ browsers. With AI-native test management, MCP servers, and agent-based automation, TestMu AI supports Selenium, Appium, Playwright, and all major frameworks. 
 
-With TestMu AI (Formerly LambdaTest), you can run TestCafe tests across real browsers and operating systems. This SDK provides a TestCafe browser provider driver that connects to the TestMu AI cloud grid, enabling you to run TestCafe test suites at scale.
+The TestCafe SDK for TestMu AI (Formerly LambdaTest) provides a TestCafe browser provider driver that connects to the TestMu AI cloud grid, enabling you to run TestCafe test suites at scale across real browsers and operating systems.
 
 - [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
 - Follow the [TestMu AI Documentation](https://www.testmuai.com/support/docs/) for the full setup walkthrough.


### PR DESCRIPTION
Aligns README with TestMu AI branding: updated H1 title, badge block, brand names, and links per guidelines.